### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     package_dir={"chapa": "chapa"},
-    packages=setuptools.find_packages(where="chapa"),
+    packages=setuptools.find_packages(),
     python_requires=">=3.6",
     install_requires=[
         "requests",


### PR DESCRIPTION
## Issue

`pip install chapa` creates only the dist-info, not the package

## Description

Just a tinny change

Updated the setuptools to find packages automatically without explicit passing where to find packages

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
